### PR TITLE
docs: bilingual project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,195 +2,148 @@
 
 # DiscordAITranslator
 
+[English](README.md) | [简体中文](README.zh-CN.md)
+
 [![Platform](https://img.shields.io/badge/Platform-Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.com)
 [![Loader](https://img.shields.io/badge/Loader-BetterDiscord-4E5D94?style=flat-square)](https://betterdiscord.app)
-[![Version](https://img.shields.io/badge/Version-0.3.39-success?style=flat-square)](https://github.com/ROOT94-MAX/DiscordAITranslator/releases)
+[![Version](https://img.shields.io/badge/Version-0.3.39-success?style=flat-square)](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest)
+[![Verify](https://img.shields.io/github/actions/workflow/status/ROOT94-MAX/DiscordAITranslator/verify.yml?branch=master&style=flat-square&label=verify)](https://github.com/ROOT94-MAX/DiscordAITranslator/actions/workflows/verify.yml)
 [![Downloads](https://img.shields.io/github/downloads/ROOT94-MAX/DiscordAITranslator/total?style=flat-square&color=yellow)](https://github.com/ROOT94-MAX/DiscordAITranslator/releases)
 [![License](https://img.shields.io/badge/License-GPL%20v2-blue?style=flat-square)](./LICENSE)
 
-一款专为 Discord 打造的智能翻译插件：发送前双语预审、接收消息自动翻译、历史消息智能补翻，内置文本保护规则与滚动稳定性保障。
+A BetterDiscord translation plugin for channel-aware incoming translation, outgoing translation, historical backfill, manual actions, forwarded messages, and protected text.
 
-**当前版本：v0.3.39** ｜ **运行环境：BetterDiscord + BDFDB Library**
+**Latest release: v0.3.39** · **Runtime: BetterDiscord + BDFDB Library**
+
+[Download latest plugin](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest/download/DiscordAITranslator.plugin.js) · [Open release notes](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest) · [Read the documentation](./docs/README.md)
 
 </div>
 
----
+## Why This Plugin
 
-## 目录
+DiscordAITranslator keeps translation controls close to the conversation instead of applying one global mode to every channel.
 
-- [效果展示](#效果展示)
-- [核心特性](#核心特性)
-- [支持的翻译服务商](#支持的翻译服务商)
-- [智能保护规则](#智能保护规则)
-- [安装指南](#安装指南)
-- [项目结构与测试](#项目结构与测试)
-- [致谢](#致谢)
-- [开源协议](#开源协议)
+- **Per-channel control:** right-click the composer translation icon to enable or pause automatic translation for the selected channel.
+- **One translation path:** live messages, historical messages, manual actions, replies, embeds, thread titles, and forwarded snapshots share the same state and restore rules.
+- **Readable history:** historical results are committed in batches, while viewport anchoring and user-intent checks reduce disruptive jumps during scroll-back.
+- **Translation integrity:** missing batch items, wrong-language output, malformed protected placeholders, and provider failures enter repair or fallback paths instead of silently disappearing.
+- **Single-file install:** modular source is built deterministically into one readable BetterDiscord plugin file.
 
----
+## Screenshots
 
-## 效果展示
+| Original conversation | Translated conversation |
+| --- | --- |
+| ![Original conversation](images/chat-overview.png) | ![Translated conversation](images/translation-effect.png) |
 
-原文截图：
+| Provider configuration | Language and history settings |
+| --- | --- |
+| ![Provider configuration](images/settings-service.png) | ![Language and history settings](images/settings-language.png) |
 
-![原文截图](images/chat-overview.png)
+## Features
 
-译文截图：
+- **Incoming translation:** automatic translation is isolated by channel, with channel-specific language choices and optional primary-provider override.
+- **Outgoing translation:** translate before sending, keep or hide the original, and use prefix-directed language selection.
+- **Historical backfill:** translate already loaded messages by scope, count, and time window; historical work remains lower priority than new live messages.
+- **Manual translation:** translate or restore a single message from its context menu even when automatic translation is disabled.
+- **Forwarded messages:** snapshot-aware extraction, translation, original display, cancellation, and restoration.
+- **Reply, embed, and title support:** reply previews, embeds, forum posts, and thread titles follow the owning channel's translation state.
+- **Original-text protection:** preserve configured terms, wrapper pairs, code-like content, spoilers, and skip prefixes through provider round trips.
+- **Primary and backup providers:** use a channel-specific primary provider while keeping credentials and backup behavior global.
+- **Cumulative history status:** the floating capsule tracks translated message IDs per channel across multiple history batches.
+- **Viewport protection:** row-level repaint is attempted first; history display waits for active scrolling to idle, and a captured reading line is restored only when user intent has not changed.
 
-![译文截图](images/translation-effect.png)
+## Supported Providers
 
----
+| Key | Provider | Credential | Notes |
+| --- | --- | :---: | --- |
+| `googleapi` | Google Free | No | Keyless default option; transport is split by encoded query size |
+| `googlecloud` | Google Cloud Translation | API key | Official Google Cloud translation service |
+| `microsoft` | Azure Translator | API key | Optional Azure region setting |
+| `deepl` | DeepL API | API key | Official DeepL translation API |
+| `deepseek` | DeepSeek | API key | AI translation, batching, and decision mode |
+| `openai` | OpenAI API | API key | Responses API with single, batch, and decision flows |
+| `gemini` | Google Gemini | API key | Native `generateContent` integration |
+| `oaicompat` | OpenAI-compatible endpoint | Endpoint, model, key | Self-hosted or third-party compatible services |
+| `yandex` | Yandex | API key | Retained compatibility provider |
 
-## 核心特性
+Provider credentials, endpoints, models, the global primary default, and the backup provider are configured in BetterDiscord settings. A channel may override only its primary provider and language choices. See [provider contracts](docs/providers.md) for the exact behavior.
 
-### 发送端：双语智能预审
-* **频道级自动化**：输入框右侧翻译图标始终显示。左键打开当前频道设置，右键切换当前频道翻译总开关；单条消息手动翻译始终独立可用。
-* **同语言跳过机制**：源语言与目标语言相同时直接发送原文。若设为“检测语言”，会优先进行本地检测，彻底告别 `中文 -> AI -> 中文改写` 的尴尬循环。
-* **AI 兜底防护**：防止 AI 引擎因误判而将原文恶性改写。
-* **隐私与防剧透**：支持附带原文一起发送，并可配置自动为原文加上 Spoiler（剧透）遮盖。
+## Quick Start
 
-### 接收端：全自动流式翻译
-* **精细化控制**：每个频道单独保存开关状态，没有全局自动开启默认值。
-* **频道主引擎覆盖**：左键打开输入框翻译面板，可为当前频道单独选择主服务商；未覆盖频道继续跟随后台全局默认，备用服务仍保持全局配置。
-* **轻量级预检测 (`useLocalLanguagePrecheck`)**：内置十几种常用语种的本地停用词表。无需网络请求即可秒级识别拉丁语系同语言消息（如英->英），高置信度时自动跳过。
-* **AI 决策安全网 (`autoTranslateDecisionMode=ai`)**：当 AI 误判“无需翻译”时，系统将通过本地书写系统快判 + Google 检测进行双重复核，确保外语消息 100% 被强制重翻。
-* **原子历史补翻**：已加载消息按 Discord 消息 ID 组成频道任务，可在内部拆分请求和逐条修复，但所有终态结果只触发一次统一显示刷新。
-* **无静默漏翻**：缺失、重复、未知、空结果、错误语言和占位符损坏都会进入修复流程；等待中的消息显示固定尺寸 CSS 加载图标。
-* **健壮的队列容错**：请求 30 秒硬超时限制；遇 `429 限流` 自动退避 5 秒，遇 `5xx 错误` 退避 2 秒，严防顶着限流连续轰炸 API。
-* **帖子与线程标题**：开启对应频道翻译后，论坛帖子和线程标题会跟随当前频道的语言与主引擎设置，停用或卸载后恢复原文。
+### Requirements
 
-### 交互与手动翻译
-* **精准正文提取**：单条消息快捷翻译只提取当前消息正文，自动剥离引用预览或剧透内容。
-* **滚动锁定技术**：翻译后触发短时间滚动锁，无论新消息涌入还是译文插入，视窗都能精准回到原消息附近。
+1. The desktop Discord client.
+2. [BetterDiscord](https://betterdiscord.app/).
+3. [BDFDB Library](https://mwittrien.github.io/downloader/?library).
 
-### 完美的滚动稳定性 (Zero-Jumping)
-* **消息锚点恢复**：自动翻译刷新时，系统会精准记录当前 `messageId` 及其距可视区域顶部的位置，并在刷新后重新定位，**彻底解决自动翻译后视角跳到中间、新消息拉到底、历史补翻视角错乱等通病**。
-* **临时拦截机制**：在打开设置页 `Select` 或点击输入框时，临时拦截 `scrollIntoView`，避免面板无故跳动。
+### Install
 
----
+1. [Download `DiscordAITranslator.plugin.js`](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest/download/DiscordAITranslator.plugin.js).
+2. Download `0BDFDB.plugin.js` from the BDFDB Library link above.
+3. Place both files in `%AppData%\BetterDiscord\plugins`.
+4. Open Discord → **User Settings** → **BetterDiscord** → **Plugins**.
+5. Enable BDFDB Library, then enable DiscordAITranslator.
+6. Open the plugin settings and configure a provider plus incoming/outgoing languages.
 
-## 支持的翻译服务商
+After replacing the plugin with a newer release, toggle it off and on once or reload Discord with `Ctrl + R`.
 
-| Key | 服务商 | 需要 API Key | 特色与说明 |
-| :--- | :--- | :---: | :--- |
-| `googleapi` | **Google (gtx)** | **否** | 默认引擎，免配置，开箱即用 |
-| `googlecloud` | **Google Cloud Translation** | 是 | 正式付费级高级 API |
-| `microsoft` | **Azure Translator** | 是 | 微软官方正式付费级 API |
-| `deepl` | **DeepL** | 是 | 行业公认高质翻译服务 |
-| `deepseek` | **DeepSeek** | 是 | 优秀国产 AI 引擎，**完美支持 AI 决策模式** |
-| `openai` | **OpenAI 官方 API** | 是 | 使用 Responses API，支持单条、批量与 AI 决策模式 |
-| `gemini` | **Google Gemini 官方 API** | 是 | 使用原生 `generateContent` 接口，支持批量与 AI 决策模式 |
-| `oaicompat` | **自定义 API (OpenAI 兼容)** | 是 | 必须显式填写真实 Endpoint 和 Model，可接入自建或第三方服务 |
-| `yandex` | **Yandex** | 是 | 兼容保留的传统服务商 |
+## Usage
 
-> 💡 **核心提示**：
-> 1. AI 决策模式（`autoTranslateDecisionMode=ai`）支持 `deepseek`、`openai`、`gemini` 和 `oaicompat`，且只有服务配置完整时才会启用。
-> 2. 插件支持配置**备用引擎 (`backup`)**，当主引擎请求失败时会自动回退，保障翻译不中断。
+- **Right-click the composer translation icon:** enable or pause automatic translation for the current channel.
+- **Left-click the composer translation icon:** open the current channel's provider and language controls.
+- **Open global plugin settings:** configure provider credentials, backup provider, detection policy, original display, protected text, and history scope.
+- **Open a message context menu:** translate, restore, detect language, or translate selected text manually.
+- **Check the history capsule:** view cumulative channel progress and retry eligible failures.
 
----
+Automatic translation has no global on-by-default switch. A channel remains off until it is explicitly enabled.
 
-## 智能保护规则
+## Known Limitations
 
-为了防止翻译破坏专业术语、代码块或特定语境，插件内置了双向保护机制：
+- Discord's internal component, Store, and forwarded-snapshot shapes are not public APIs and may require adaptation after client updates.
+- A whole-chat repaint remains as a fallback when row-level confirmation or a reply host cannot satisfy a display transaction; this can still cause occasional mild composer flicker.
+- Adding translated text changes row and total-list height. The plugin protects the reader's message position, but the scrollbar thumb can still move or resize.
+- Keyless and third-party providers may apply quotas, rate limits, payload limits, regional restrictions, or output transformations outside the plugin's control.
+- PTB observation is still required for render-boundary changes even when the automated suite passes.
 
-* **专有名词保护**：支持配置固定术语、产品名、团队名（如 `BUG team`, `DeepSeek V3`）。匹配时自动忽略内部空格（如配置 “BUG team” 也会自动保护 “bugteam”）。
-* **自动化免翻豁免**：内置版本号、全大写缩写（如 `CDK` / `GPT` / `API`）自动免翻保护。但若识别到全大写喊话文本（如 `HELLO CRYZYYY`），则会豁免该规则进行正常翻译。
-* **自动包裹符隔离**：成段隔离保护，格式为 `左包裹符|右包裹符`。默认支持 `"|"`、`“|”`、`` `|` ``、`【|】`、`「|」`。*(注：`||` 不再作为普通包裹符，确保剧透内容不会被错误阻断)*
-* **全局跳过前缀**：支持自定义跳过前缀（如以 `!` 开头的消息），直接不触发翻译逻辑。
+For proven causes, rejected approaches, and remaining observation items, read the [field-debugging handoff](docs/field-debugging-guide.md) or its [Simplified Chinese version](docs/field-debugging-guide.zh-CN.md).
 
----
+## Development
 
-## 安装指南
-
-### 前置依赖
-1. 官方原生 **Discord** 客户端。
-2. 安装 **BetterDiscord** 插件加载器。
-3. 下载 **BDFDB Library**：[点击前往下载](https://mwittrien.github.io/downloader/?library)
-
-### 安装步骤
-
-> 💡 推荐直接从 [Releases 页面](https://github.com/ROOT94-MAX/DiscordAITranslator/releases) 下载 `DiscordAITranslator.plugin.js`，无需 clone 整个仓库。
-
-1. 将 `DiscordAITranslator.plugin.js` 移动至插件目录 `%AppData%\BetterDiscord\plugins`。
-2. 将下载好的 `BDFDB Library` 文件（通常为 `0BDFDB.plugin.js`）放置到同一目录下。
-3. 打开 Discord -> `设置` -> `BetterDiscord` -> `插件`，开启 **DiscordAITranslator**。
-4. 点击插件设置，选择你心仪的翻译服务商，配置语言后即可开始使用！
-
-> 🔄 **版本更新提示**：替换新版插件后，请在插件页面重新开关一次，或者在 Discord 界面中直接按下 `Ctrl + R` 重载客户端。
-
-### 配置示例
-
-翻译服务配置：选择服务商、填写 API Key / Endpoint / Model（图为 DeepSeek）：
-
-![翻译服务配置](images/settings-service.png)
-
-语言与自动翻译策略：设置收发语言、主备引擎、补翻范围与每批数量：
-
-![语言与自动翻译策略](images/settings-language.png)
-
-### 推荐搭配：system24 主题
-
-打开 BetterDiscord 主题页，直接导入以下直链：
+The repository keeps modular source under `src/` and generates the single installable plugin deterministically.
 
 ```text
-https://refact0r.github.io/system24/build/system24.css
+src/plugin/index.js
+        -> scripts/build-plugin.mjs
+        -> DiscordAITranslator.plugin.js
 ```
 
----
-
-## 项目结构与测试
-
-自 v0.3.38 起源码已模块化：`src/` 下的模块由构建脚本确定性打包为单文件产物，BetterDiscord 用户只需安装一个 `DiscordAITranslator.plugin.js`。
-
-```text
-discord翻译/
-├── DiscordAITranslator.plugin.js   # 构建产物（BetterDiscord 安装入口，勿手改）
-├── src/                            # 模块化源码
-│   ├── plugin/                     # 入口与插件元数据（版本号在此维护）
-│   ├── legacy/                     # 迁移中的组合根与补丁外壳
-│   ├── display/                    # 显示状态仓库、事务控制器、渲染适配
-│   ├── orchestrator/               # 实时/历史队列、频道切换、分块传输
-│   ├── received/                   # 接收消息翻译管线与历史消息源
-│   ├── sent/                       # 发送消息翻译管线
-│   ├── providers/                  # 翻译服务商客户端
-│   ├── settings/                   # 设置存储与迁移
-│   ├── status/                     # 状态胶囊
-│   ├── ui/                         # 设置面板与交互组件
-│   └── cache/ viewport/ language/ protection/ …
-├── scripts/build-plugin.mjs        # 确定性构建（esbuild，含 @buildId 指纹）
-├── tests/                          # 自动化回归测试套件
-├── docs/                           # 权威文档（索引见 docs/README.md）
-├── AGENTS.md / CONTRIBUTING.md     # 项目规则与开发流程
-└── package.json                    # 构建、检查与测试命令
-```
-
-### 本地测试校验
-
-安装 Node.js 20 或更高版本后，统一运行：
+Requirements: Node.js 20 or newer.
 
 ```powershell
-npm run build      # 从 src/ 重新生成插件文件
-npm run verify     # 构建校验 + 语法检查 + 全部测试（部署前必跑）
+npm ci
+npm run build
+npm run verify
 ```
 
-注意：测试会加载生成的插件文件，改动 `src/` 后请先 `npm run build` 再跑聚焦测试，否则执行的是旧产物。只运行某一个回归文件时可以使用 `npm test -- tests/translation-regression.test.js`。
+`npm run verify` checks source/artifact parity, JavaScript syntax, architecture budgets, release metadata, bilingual documentation entry points, and the complete unit/contract/integration suite. Do not edit the generated plugin by hand.
 
-完整版本历史见 [CHANGELOG.md](./CHANGELOG.md)，技术细节见 [docs/](./docs/)。
+Contribution rules and repository invariants are documented in [CONTRIBUTING.md](./CONTRIBUTING.md) and [AGENTS.md](./AGENTS.md).
 
----
+## Documentation
 
-## 致谢
+- Product behavior: [docs/product.md](docs/product.md)
+- Setting ownership: [docs/settings.md](docs/settings.md)
+- Provider contracts: [docs/providers.md](docs/providers.md)
+- Architecture: [English](docs/architecture.md) | [简体中文](docs/architecture.zh-CN.md)
+- Field-debugging handoff: [English](docs/field-debugging-guide.md) | [简体中文](docs/field-debugging-guide.zh-CN.md)
+- Active recovery plan: [docs/recovery-plan.md](docs/recovery-plan.md)
+- Release history: [CHANGELOG.md](./CHANGELOG.md)
 
-本插件基于 BetterDiscord 原版 `Translator` 插件进行二次开发。衷心感谢以下上游项目及作者的开源贡献：
+## Credits
 
-* **上游原版**：[mwittrien/BetterDiscordAddons](https://github.com/mwittrien/BetterDiscordAddons) 的 `Translator` 核心。
-* **运行时基建**：[mwittrien/BDFDB](https://mwittrien.github.io/downloader/?library) 库。
-* **主题美化**：[refact0r/system24](https://github.com/refact0r/system24) 的极简美学设计。
+- Original BetterDiscord Translator foundation: [mwittrien/BetterDiscordAddons](https://github.com/mwittrien/BetterDiscordAddons)
+- Runtime library: [BDFDB](https://mwittrien.github.io/downloader/?library)
 
----
+## License
 
-## 开源协议
-
-本项目基于 [GNU General Public License v2.0](./LICENSE) 开源。你可以自由使用、修改和分发，但再分发或衍生作品必须同样采用 GPL v2.0 协议发布。
-
-本项目基于 mwittrien/BetterDiscordAddons 的 Translator 插件二次开发，上游同样采用 GPL v2.0 协议。
+Licensed under [GNU General Public License v2.0](./LICENSE). Redistribution and derivative work must remain compatible with GPL v2.0. The upstream Translator foundation is also GPL v2.0.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,149 @@
+<div align="center">
+
+# DiscordAITranslator
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+[![平台](https://img.shields.io/badge/Platform-Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.com)
+[![加载器](https://img.shields.io/badge/Loader-BetterDiscord-4E5D94?style=flat-square)](https://betterdiscord.app)
+[![版本](https://img.shields.io/badge/Version-0.3.39-success?style=flat-square)](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest)
+[![验证](https://img.shields.io/github/actions/workflow/status/ROOT94-MAX/DiscordAITranslator/verify.yml?branch=master&style=flat-square&label=verify)](https://github.com/ROOT94-MAX/DiscordAITranslator/actions/workflows/verify.yml)
+[![下载量](https://img.shields.io/github/downloads/ROOT94-MAX/DiscordAITranslator/total?style=flat-square&color=yellow)](https://github.com/ROOT94-MAX/DiscordAITranslator/releases)
+[![许可证](https://img.shields.io/badge/License-GPL%20v2-blue?style=flat-square)](./LICENSE)
+
+一款 BetterDiscord 翻译插件，支持频道级收到消息翻译、发送前翻译、历史补翻、手动操作、转发消息和受保护文本。
+
+**当前版本：v0.3.39** · **运行环境：BetterDiscord + BDFDB Library**
+
+[下载最新版插件](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest/download/DiscordAITranslator.plugin.js) · [查看发布说明](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest) · [阅读技术文档](./docs/README.md)
+
+</div>
+
+## 为什么使用它
+
+DiscordAITranslator 把翻译控制放在当前会话附近，而不是使用一个影响全部频道的全局开关。
+
+- **频道级控制：**右键输入框翻译图标，只为当前频道开启或暂停自动翻译。
+- **统一翻译链：**实时消息、历史消息、手动操作、回复、embed、线程标题和转发快照使用同一套状态与恢复规则。
+- **历史阅读保护：**历史结果按批次提交，结合阅读行锚点和用户意图判断，减少上滚查看时的干扰。
+- **结果完整性：**批量缺项、错误语言、保护占位符损坏和供应商失败会进入修复或备用路径，而不是静默消失。
+- **单文件安装：**模块化源码会确定性构建为一份可读的 BetterDiscord 插件文件。
+
+## 效果展示
+
+| 原始会话 | 翻译后的会话 |
+| --- | --- |
+| ![原始会话](images/chat-overview.png) | ![翻译后的会话](images/translation-effect.png) |
+
+| 供应商配置 | 语言与历史设置 |
+| --- | --- |
+| ![供应商配置](images/settings-service.png) | ![语言与历史设置](images/settings-language.png) |
+
+## 核心功能
+
+- **收到消息翻译：**自动翻译按频道隔离，每个频道可设置语言并可选覆盖主供应商。
+- **发送消息翻译：**发送前翻译，可选择是否附带原文，也支持通过前缀指定目标语言。
+- **历史消息补翻：**按范围、数量和时间窗口翻译已加载消息；历史工作不会抢占新实时消息。
+- **手动翻译：**即使频道自动翻译关闭，也可以从消息右键菜单翻译或恢复单条消息。
+- **转发消息支持：**识别转发快照正文，并统一处理翻译、原文显示、取消和恢复。
+- **回复、embed 与标题：**回复预览、embed、论坛帖子和线程标题跟随所属频道翻译状态。
+- **原文保护：**在供应商往返过程中保护自定义术语、包裹符、代码式文本、剧透和跳过前缀。
+- **主备供应商：**频道可覆盖主供应商，凭证和备用供应商仍保持全局配置。
+- **累计历史状态：**浮动胶囊按频道累计唯一已翻译消息，跨多个历史批次继续增长。
+- **视口保护：**优先尝试单行重绘；用户正在滚动时延迟历史显示，只在用户意图未改变时恢复阅读行。
+
+## 支持的翻译服务商
+
+| Key | 服务商 | 凭证 | 说明 |
+| --- | --- | :---: | --- |
+| `googleapi` | Google Free | 无 | 免密钥默认选项；按编码后的查询大小切片 |
+| `googlecloud` | Google Cloud Translation | API Key | Google Cloud 官方翻译服务 |
+| `microsoft` | Azure Translator | API Key | 支持可选 Azure Region |
+| `deepl` | DeepL API | API Key | DeepL 官方翻译 API |
+| `deepseek` | DeepSeek | API Key | 支持 AI 翻译、批量和决策模式 |
+| `openai` | OpenAI API | API Key | Responses API，支持单条、批量和决策流程 |
+| `gemini` | Google Gemini | API Key | 原生 `generateContent` 接口 |
+| `oaicompat` | OpenAI 兼容端点 | Endpoint、Model、Key | 可接入自建或第三方兼容服务 |
+| `yandex` | Yandex | API Key | 保留的兼容供应商 |
+
+供应商凭证、端点、模型、全局主供应商默认值和备用供应商都在 BetterDiscord 设置中配置。频道只能覆盖自己的主供应商和语言选择。准确行为见[供应商契约](docs/providers.md)。
+
+## 快速安装
+
+### 前置条件
+
+1. 桌面版 Discord 客户端。
+2. [BetterDiscord](https://betterdiscord.app/)。
+3. [BDFDB Library](https://mwittrien.github.io/downloader/?library)。
+
+### 安装步骤
+
+1. [下载 `DiscordAITranslator.plugin.js`](https://github.com/ROOT94-MAX/DiscordAITranslator/releases/latest/download/DiscordAITranslator.plugin.js)。
+2. 从上面的 BDFDB Library 地址下载 `0BDFDB.plugin.js`。
+3. 把两个文件放进 `%AppData%\BetterDiscord\plugins`。
+4. 打开 Discord → **用户设置** → **BetterDiscord** → **插件**。
+5. 先启用 BDFDB Library，再启用 DiscordAITranslator。
+6. 打开插件设置，配置翻译供应商以及收发语言。
+
+替换新版插件后，请重新开关一次插件，或使用 `Ctrl + R` 重载 Discord。
+
+## 使用方法
+
+- **右键输入框翻译图标：**开启或暂停当前频道自动翻译。
+- **左键输入框翻译图标：**打开当前频道供应商和语言控制。
+- **打开插件全局设置：**配置供应商凭证、备用供应商、检测策略、原文显示、文本保护和历史范围。
+- **打开消息右键菜单：**手动翻译、恢复、检测语言或翻译选中文本。
+- **查看历史状态胶囊：**查看频道累计进度，并重试符合条件的失败项。
+
+自动翻译没有全局默认开启开关；只有用户明确开启的频道才会自动翻译。
+
+## 已知限制
+
+- Discord 内部组件、Store 和转发快照结构不是公开 API，客户端更新后可能需要重新适配。
+- 单行确认或回复宿主未满足显示事务时，仍会回退到整聊天区重绘，因此偶尔可能看到轻微输入框图标闪烁。
+- 译文会增加消息行和列表总高度；插件保护阅读消息位置，但滚动条滑块仍可能移动或改变大小。
+- 免密钥和第三方供应商可能存在额度、限流、负载大小、区域或输出转换限制，这些不完全由插件控制。
+- 即使自动化测试通过，涉及 Discord 渲染边界的变化仍需要 PTB 实际观察。
+
+已证实原因、失败路线和剩余观察项见[中文现场调试交接](docs/field-debugging-guide.zh-CN.md)或其[英文版本](docs/field-debugging-guide.md)。
+
+## 开发与验证
+
+仓库在 `src/` 中维护模块化源码，并确定性生成一份可安装插件。
+
+```text
+src/plugin/index.js
+        -> scripts/build-plugin.mjs
+        -> DiscordAITranslator.plugin.js
+```
+
+要求 Node.js 20 或更高版本。
+
+```powershell
+npm ci
+npm run build
+npm run verify
+```
+
+`npm run verify` 会检查源码/产物一致性、JavaScript 语法、架构约束、发布元数据、双语文档入口和完整单元/契约/集成测试。请勿手工编辑生成的插件文件。
+
+贡献规则和仓库不变量见 [CONTRIBUTING.md](./CONTRIBUTING.md) 与 [AGENTS.md](./AGENTS.md)。
+
+## 技术文档
+
+- 产品行为：[docs/product.md](docs/product.md)
+- 设置归属：[docs/settings.md](docs/settings.md)
+- 供应商契约：[docs/providers.md](docs/providers.md)
+- 架构：[English](docs/architecture.md) | [简体中文](docs/architecture.zh-CN.md)
+- 现场调试交接：[English](docs/field-debugging-guide.md) | [简体中文](docs/field-debugging-guide.zh-CN.md)
+- 当前恢复计划：[docs/recovery-plan.md](docs/recovery-plan.md)
+- 发布历史：[CHANGELOG.md](./CHANGELOG.md)
+
+## 致谢
+
+- BetterDiscord Translator 原始基础：[mwittrien/BetterDiscordAddons](https://github.com/mwittrien/BetterDiscordAddons)
+- 运行时库：[BDFDB](https://mwittrien.github.io/downloader/?library)
+
+## 开源协议
+
+本项目使用 [GNU General Public License v2.0](./LICENSE)。再分发和衍生作品必须保持 GPL v2.0 兼容；上游 Translator 基础同样采用 GPL v2.0。

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the canonical project documentation.
 
+Project overview: [English](../README.md) | [简体中文](../README.zh-CN.md)
+
 ## Reading Order
 
 1. [Product behavior](product.md)

--- a/tests/release-contract.test.js
+++ b/tests/release-contract.test.js
@@ -14,6 +14,7 @@ test("release metadata, README and changelog agree on v0.3.39", () => {
 	const packageLock = readJson("package-lock.json");
 	const metadata = readJson("src/plugin/metadata.json");
 	const readme = read("README.md");
+	const readmeZh = read("README.zh-CN.md");
 	const changelog = read("CHANGELOG.md");
 	const plugin = read("DiscordAITranslator.plugin.js");
 
@@ -22,9 +23,63 @@ test("release metadata, README and changelog agree on v0.3.39", () => {
 	assert.equal(packageLock.packages[""].version, RELEASE_VERSION);
 	assert.equal(metadata.version, RELEASE_VERSION);
 	assert.match(readme, new RegExp(`Version-${escapeRegex(RELEASE_VERSION)}-`));
-	assert.match(readme, new RegExp(`当前版本：v${escapeRegex(RELEASE_VERSION)}`));
+	assert.match(readme, new RegExp(`Latest release: v${escapeRegex(RELEASE_VERSION)}`));
+	assert.match(readmeZh, new RegExp(`当前版本：v${escapeRegex(RELEASE_VERSION)}`));
 	assert.match(changelog, new RegExp(`^## v${escapeRegex(RELEASE_VERSION)}$`, "m"));
 	assert.match(plugin, new RegExp(`^ \\* @version ${escapeRegex(RELEASE_VERSION)}$`, "m"));
+});
+
+test("root README offers complete English and Simplified Chinese mirrors", () => {
+	const english = read("README.md");
+	const chinese = read("README.zh-CN.md");
+	const languageSwitch = "[English](README.md) | [简体中文](README.zh-CN.md)";
+	const latestDownload = "releases/latest/download/DiscordAITranslator.plugin.js";
+
+	assert.match(english, new RegExp(escapeRegex(languageSwitch)));
+	assert.match(chinese, new RegExp(escapeRegex(languageSwitch)));
+	assert.match(english, new RegExp(escapeRegex(latestDownload)));
+	assert.match(chinese, new RegExp(escapeRegex(latestDownload)));
+
+	for (const heading of [
+		"## Why This Plugin",
+		"## Screenshots",
+		"## Features",
+		"## Supported Providers",
+		"## Quick Start",
+		"## Usage",
+		"## Known Limitations",
+		"## Development",
+		"## Documentation",
+		"## Credits",
+		"## License"
+	]) assert.match(english, new RegExp(`^${escapeRegex(heading)}$`, "m"));
+
+	for (const heading of [
+		"## 为什么使用它",
+		"## 效果展示",
+		"## 核心功能",
+		"## 支持的翻译服务商",
+		"## 快速安装",
+		"## 使用方法",
+		"## 已知限制",
+		"## 开发与验证",
+		"## 技术文档",
+		"## 致谢",
+		"## 开源协议"
+	]) assert.match(chinese, new RegExp(`^${escapeRegex(heading)}$`, "m"));
+
+	assert.doesNotMatch(english, /\bperfect\b|zero-jumping|\b100%\b/i);
+	assert.doesNotMatch(chinese, /完美|彻底解决|100%/);
+
+	const imagePattern = /\]\((images\/[^)]+)\)/g;
+	const englishImages = [...english.matchAll(imagePattern)].map(match => match[1]).sort();
+	const chineseImages = [...chinese.matchAll(imagePattern)].map(match => match[1]).sort();
+	assert.deepEqual(chineseImages, englishImages, "both README languages use the same screenshots");
+	assert.ok(englishImages.length >= 4, "the README keeps the product and settings screenshots");
+
+	const docsIndex = read("docs/README.md");
+	assert.match(docsIndex, /\.\.\/README\.md/);
+	assert.match(docsIndex, /\.\.\/README\.zh-CN\.md/);
 });
 
 test("architecture and field handoff provide complete Chinese companion entry points", () => {


### PR DESCRIPTION
## 摘要

- 将仓库默认 `README.md` 重写为英文版，并新增完整 `README.zh-CN.md`
- 两种语言顶部提供 `English | 简体中文` 切换，结构、截图、供应商和版本保持一致
- 优化下载、安装、使用、限制和技术文档入口，移除“完美”“100%”“彻底解决”等过度承诺
- 增加 README 双语发布契约，防止版本、下载、章节和图片后续漂移

## 验证

- README 双语契约 RED/GREEN 已验证
- 本地链接缺失：0
- 英文/中文：各 149 行、11 个主章节、4 张截图
- `npm run verify`：1250/1250 通过